### PR TITLE
case helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   PUB_ENVIRONMENT: bot.github
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -35,6 +35,8 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
         if: always() && steps.install.outcome == 'success'
       - run: dart analyze --fatal-infos
-        if: always() && steps.install.outcome == 'success'
+        if: matrix.sdk == 'dev' && steps.install.outcome == 'success'
+      - run: dart analyze --no-fatal-warnings
+        if: matrix.sdk != 'dev' && steps.install.outcome == 'success'
       - run: dart test
         if: always() && steps.install.outcome == 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.2.2-dev
+## 1.3.0
 
-- Add an example
+- Added `extension CaseHelper on String` to preform common, identifier-related
+  conversions.
+- Added an example
 
 ## 1.2.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -62,6 +62,7 @@ linter:
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null
     - provide_deprecation_message
+    - require_trailing_commas
     - sort_pub_dependencies
     - test_types_in_equals
     - throw_in_finally

--- a/example/example.dart
+++ b/example/example.dart
@@ -18,11 +18,13 @@ import 'package:source_helper/source_helper.dart';
 /// when generating Dart source code.
 void main() {
   for (var item in _examples) {
-    print('''
+    print(
+      '''
 ----- Input
 $item
 ----- Output
-${escapeDartString(item)}''');
+${escapeDartString(item)}''',
+    );
   }
 }
 

--- a/lib/source_helper.dart
+++ b/lib/source_helper.dart
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export 'src/case_helpers.dart' show CaseHelper;
 export 'src/dart_type_extension.dart' show DartTypeExtension;
 export 'src/escape_dart_string.dart' show escapeDartString;

--- a/lib/src/case_helpers.dart
+++ b/lib/src/case_helpers.dart
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Extensions getters on [String] to preform common, identifier-related
+/// conversions.
+extension CaseHelper on String {
+  /// Returns `this` converted to
+  /// [kebab-case](https://en.wikipedia.org/wiki/Kebab_case),
+  /// where words are seperated by a hyphen.
+  ///
+  /// Examples:
+  ///
+  /// ```text
+  /// 'simple'   -> 'simple',
+  /// 'twoWords' -> 'two-words'
+  /// 'FirstBig' -> 'first-big'
+  /// ```
+  ///
+  /// Whitespace is not considered or affected.
+  String get kebab => _fixCase('-');
+
+  /// Returns `this` converted to
+  /// [snake_case](https://en.wikipedia.org/wiki/Snake_case),
+  /// where words are seperated by underscore.
+  ///
+  /// Examples:
+  ///
+  /// ```text
+  /// 'simple'   -> 'simple',
+  /// 'twoWords' -> 'two_words'
+  /// 'FirstBig' -> 'first_big'
+  /// ```
+  ///
+  /// Whitespace is not considered or affected.
+  String get snake => _fixCase('_');
+
+  /// Returns `this` where the first character is capitalized.
+  ///
+  /// Examples:
+  ///
+  /// ```text
+  /// 'simple'   -> 'Simple',
+  /// 'twoWords' -> 'TwoWords'
+  /// 'FirstBig' -> 'FirstBig'
+  /// ```
+  ///
+  /// Whitespace is not considered or affected.
+  String get pascal {
+    if (isEmpty) {
+      return '';
+    }
+
+    return this[0].toUpperCase() + substring(1);
+  }
+
+  String _fixCase(String separator) => replaceAllMapped(_upperCase, (match) {
+        var lower = match.group(0)!.toLowerCase();
+
+        if (match.start > 0) {
+          lower = '$separator$lower';
+        }
+
+        return lower;
+      });
+
+  /// Returns `this` with all leading underscore characters removed.
+  String get nonPrivate => replaceFirst(RegExp(r'^_*'), '');
+}
+
+final _upperCase = RegExp('[A-Z]');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,6 @@ dependencies:
   source_gen: ^1.0.0
 
 dev_dependencies:
-  pedantic: ^1.0.0
+  lints: ^1.0.0
   test: ^1.16.0
   test_descriptor: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@
 name: source_helper
 description: Utilities to help with Dart source code generation. Includes
   utilities for properly generating String literals from any String value.
-version: 1.2.2-dev
+version: 1.3.0
 repository: https://github.com/google/source_helper.dart
 
 environment:

--- a/test/case_test.dart
+++ b/test/case_test.dart
@@ -1,0 +1,55 @@
+import 'package:source_helper/source_helper.dart';
+import 'package:test/test.dart';
+
+const _kebabItems = {
+  'simple': 'simple',
+  'twoWords': 'two-words',
+  'FirstBig': 'first-big'
+};
+
+const _pascalItems = {
+  'simple': 'Simple',
+  'twoWords': 'TwoWords',
+  'FirstBig': 'FirstBig'
+};
+
+const _snakeItems = {
+  'simple': 'simple',
+  'twoWords': 'two_words',
+  'FirstBig': 'first_big',
+};
+
+void main() {
+  group('kebab', () {
+    for (final entry in _kebabItems.entries) {
+      test('"${entry.key}"', () {
+        expect(entry.key.kebab, entry.value);
+      });
+    }
+  });
+
+  group('pascal', () {
+    for (final entry in _pascalItems.entries) {
+      test('"${entry.key}"', () {
+        expect(entry.key.pascal, entry.value);
+      });
+    }
+  });
+
+  group('snake', () {
+    for (final entry in _snakeItems.entries) {
+      test('"${entry.key}"', () {
+        expect(entry.key.snake, entry.value);
+      });
+    }
+  });
+
+  group('nonPrivateName', () {
+    test('removes leading underscores', () {
+      expect('__hello__world__'.nonPrivate, equals('hello__world__'));
+    });
+    test('does not changes public names', () {
+      expect('HelloWorld'.nonPrivate, equals('HelloWorld'));
+    });
+  });
+}

--- a/test/escape_dart_string_test.dart
+++ b/test/escape_dart_string_test.dart
@@ -39,11 +39,15 @@ void main() {
       workingDirectory: d.sandbox,
     );
 
-    expect(result.exitCode, 0, reason: '''
+    expect(
+      result.exitCode,
+      0,
+      reason: '''
 Process did not complete!
 Exit code: ${result.exitCode}
 ${result.stdout}
-${result.stderr}''');
+${result.stderr}''',
+    );
 
     final roundTripList = _decodeJsonStringList(result.stdout as String);
 


### PR DESCRIPTION
- Switch to recommended lints
- require trailing commas
- Add `extension CaseHelper on String` for identifier-related conversions
