### PR TITLE
blast repo changes: dependabot, no-response

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
   labels:
     - autosubmit
   groups:
-    dependencies:
+    github-actions:
       patterns:
         - "*"

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'google' }}
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           # Don't automatically mark inactive issues+PRs as stale.
           days-before-stale: -1


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `dependabot`
- `no-response`