### PR TITLE
Allow source_gen 3.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 1.3.6-wip
+## 1.3.6
 
 - Require `analyzer: ^7.3.0`
-- Require `source_gen: ^2.0.0`
+- Require `source_gen: >=2.0.0 <4.0.0`
 - Require `sdk: ^3.6.0`
 
 ## 1.3.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@
 name: source_helper
 description: Utilities to help with Dart source code generation. Includes
   utilities for properly generating String literals from any String value.
-version: 1.3.6-wip
+version: 1.3.6
 repository: https://github.com/google/source_helper.dart
 
 environment:
@@ -22,7 +22,7 @@ environment:
 
 dependencies:
   analyzer: ^7.3.0
-  source_gen: ^2.0.0
+  source_gen: '>=2.0.0 <4.0.0'
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
Needed for `json_serializable` element2 migration.