### PR TITLE
test: expand string escaping sanity tests

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,4 +25,5 @@ linter:
     - prefer_final_locals
     - require_trailing_commas
     - unnecessary_await_in_return
+    - unnecessary_ignore
     - use_string_buffers

--- a/lib/src/escape_dart_string.dart
+++ b/lib/src/escape_dart_string.dart
@@ -52,7 +52,7 @@ String escapeDartString(String value) {
   if (hasDollar && canBeRaw) {
     if (hasSingleQuote) {
       if (!hasDoubleQuote) {
-        // quote it with single quotes!
+        // quote it with double quotes!
         return 'r"$value"';
       }
     } else {
@@ -62,7 +62,7 @@ String escapeDartString(String value) {
   }
 
   // The only safe way to wrap the content is to escape all of the
-  // problematic characters - `$`, `'`, and `"`
+  // problematic characters - `$` and `'`
   final string = value.replaceAll(_dollarQuoteRegexp, r'\');
   return "'$string'";
 }

--- a/test/escape_dart_string_test.dart
+++ b/test/escape_dart_string_test.dart
@@ -20,6 +20,31 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
+  group('escapeDartString unit tests', () {
+    test('simple string', () {
+      expect(escapeDartString('hello'), "'hello'");
+    });
+
+    test('string with single quote', () {
+      expect(escapeDartString("it's a test"), '"it\'s a test"');
+    });
+
+    test('string with double quote', () {
+      expect(escapeDartString('hello "world"'), "'hello \"world\"'");
+    });
+
+    test('various string types', () {
+      expect(escapeDartString('hello'), "'hello'");
+      expect(escapeDartString("it's a test"), '"it\'s a test"');
+      expect(escapeDartString('hello "world"'), "'hello \"world\"'");
+      expect(escapeDartString('''it's "test"'''), r"""'it\'s "test"'""");
+      expect(escapeDartString(r'$hello'), r"r'$hello'");
+      expect(escapeDartString(r"$ it's"), r'''r"$ it's"''');
+      expect(escapeDartString('a\nb'), r"'a\nb'");
+      expect(escapeDartString(r'hello\world'), r"'hello\\world'");
+    });
+  });
+
   test('generate and validate', () async {
     final originalList = _decodeJsonStringList(
       File(


### PR DESCRIPTION
- Added isolated unit tests for `escapeDartString` to cover common string interpolations and quote boundary edge cases, providing fast feedback before the heavy BLNS integration test suite runs.
- Corrected misleading inline documentation surrounding double-quote handling.
- Enabled `unnecessary_ignore` lint rule in `analysis_options.yaml`.
